### PR TITLE
Add support exar usb-serial ports

### DIFF
--- a/serial/tools/list_ports_linux.py
+++ b/serial/tools/list_ports_linux.py
@@ -89,6 +89,7 @@ class SysFS(list_ports_common.ListPortInfo):
 def comports(include_links=False):
     devices = glob.glob('/dev/ttyS*')           # built-in serial ports
     devices.extend(glob.glob('/dev/ttyUSB*'))   # usb-serial with own driver
+    devices.extend(glob.glob('/dev/ttyXRUSB*')) # xr-usb-serial port exar (DELL Edge 3001)
     devices.extend(glob.glob('/dev/ttyACM*'))   # usb-serial with CDC-ACM profile
     devices.extend(glob.glob('/dev/ttyAMA*'))   # ARM internal port (raspi)
     devices.extend(glob.glob('/dev/rfcomm*'))   # BT serial devices


### PR DESCRIPTION
Add support [exar](https://www.exar.com/product/interface/uarts/usb-uarts/xr21v1412) usb-serial ports seen on DELL Edge gateways (300x series)
